### PR TITLE
ユーザページで投稿一覧リストのコンポーネントを仮データで表示できるようにした

### DIFF
--- a/server/front/src/views/UserPage.vue
+++ b/server/front/src/views/UserPage.vue
@@ -1,8 +1,11 @@
 <template>
-  <user-info
-    v-if="user"
-    :user="user"
-  />
+  <div>
+    <user-info
+      v-if="user"
+      :user="user"
+    />
+    <post-list />
+  </div>
 </template>
 
 <script lang="ts">
@@ -10,8 +13,9 @@ import { Component, Vue }from 'vue-property-decorator';
 import { CreateUserApplication }from '../create/CreateUserApplication';
 import { UserDto }from '../domain/user/UserDto';
 import UserInfo from '../components/userPage/UserInfo.vue';
+import PostList from '../components/PostList.vue';
 
-@Component({ components: { UserInfo } })
+@Component({ components: { UserInfo, PostList } })
 export default class extends Vue {
   user: UserDto | null = null;
 
@@ -22,4 +26,3 @@ export default class extends Vue {
   }
 }
 </script>
- 


### PR DESCRIPTION
## 変更内容
<!-- ビューの変更がある場合はスクショによる比較などがあるとわかりやすい -->
<img width="398" alt="スクリーンショット 2019-10-25 16 19 23" src="https://user-images.githubusercontent.com/39879933/67551166-3aa0d880-f743-11e9-96a9-990e902bccc1.png">

## 影響範囲
<!-- この関数を変更したのでこの機能にも影響がある、など -->

## 動作要件
<!-- 動作に必要な 環境変数 / 依存関係 / DBの更新 など -->

## 補足
<!-- レビューをする際に見てほしい点、ローカル環境で試す際の注意点、など -->